### PR TITLE
fix(charts/ack-ai-dashboard): increase the memory limit for admin-ui from 500Mi to 2Gi

### DIFF
--- a/charts/ack-ai-dashboard/values.yaml
+++ b/charts/ack-ai-dashboard/values.yaml
@@ -83,7 +83,7 @@ admin-ui:
   resources:
     limits:
       cpu: 2000m
-      memory: 500Mi
+      memory: 2Gi
     requests:
       cpu: 500m
       memory: 100Mi


### PR DESCRIPTION
## Proposed Changes

- Increase the memory limit for admin-ui from `500Mi` to `2Gi` to avoid OOMKilled issue.

## Why this is needed?

Closes #6 .