### PR TITLE
docs: add GitHub Pages with Jekyll (just-the-docs theme)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,48 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,14 @@
+title: Data on ACK
+description: 基于阿里云 ACK 的云原生 AI/ML 平台文档
+remote_theme: just-the-docs/just-the-docs@v0.10.0
+
+url: "https://aliyuncontainerservice.github.io"
+baseurl: "/data-on-ack"
+
+aux_links:
+  "GitHub":
+    - "https://github.com/AliyunContainerService/data-on-ack"
+
+nav_enabled: true
+
+footer_content: "Copyright &copy; 2024-2026 Alibaba Cloud. Distributed under the <a href=\"https://github.com/AliyunContainerService/data-on-ack/blob/main/LICENSE\">Apache-2.0 license.</a>"

--- a/docs/deploy-guide.md
+++ b/docs/deploy-guide.md
@@ -1,3 +1,9 @@
+---
+title: 部署指南
+layout: default
+nav_order: 2
+---
+
 # 部署指南：在 ACK 上安装 AI 开发平台
 
 本文介绍如何在阿里云容器服务 ACK（Kubernetes）集群上部署 data-on-ack AI 开发平台，包含运维控制台（ai-dashboard）和开发控制台（ai-dev-console）。

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,34 @@
+---
+title: 首页
+layout: default
+nav_order: 1
+---
+
+# Data on ACK 文档
+
+Data on ACK 是一个基于阿里云容器服务 ACK 的开源云原生 AI/ML 平台，为数据科学家和算法工程师提供模型开发、训练和管理的完整工具链。
+
+## 文档导航
+
+| 文档 | 说明 |
+|------|------|
+| [部署指南](deploy-guide) | 在 ACK 集群上安装 AI 开发平台的完整步骤 |
+| [功能使用指南](user-guide) | 运维控制台和开发控制台的核心功能介绍 |
+| [运维指南](ops-guide) | 日常运维操作：升级、扩缩容、故障排查、备份恢复 |
+
+## 平台组件
+
+- **ai-dashboard** — 集群运维控制台（管理员视角）
+- **ai-dev-console** — 模型开发控制台（算法工程师视角）
+- **commit-agent** — Jupyter Notebook 代码同步 Agent
+- **notebook-controller** — Notebook CRD 控制器
+
+## 快速开始
+
+```bash
+# 添加 Helm 仓库并安装
+helm install ack-ai-dashboard charts/ack-ai-dashboard -n China-system
+helm install ack-ai-dev-console charts/ack-ai-dev-console -n China-system
+```
+
+详细步骤请参考 [部署指南](deploy-guide)。

--- a/docs/ops-guide.md
+++ b/docs/ops-guide.md
@@ -1,3 +1,9 @@
+---
+title: 运维指南
+layout: default
+nav_order: 4
+---
+
 # 运维指南
 
 本文介绍 data-on-ack AI 平台的日常运维操作，包括升级、扩缩容、故障排查和备份恢复。

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,3 +1,9 @@
+---
+title: 功能使用指南
+layout: default
+nav_order: 3
+---
+
 # 功能使用指南
 
 本文介绍 data-on-ack AI 平台的核心功能和使用方法。


### PR DESCRIPTION
- Add Jekyll _config.yml with just-the-docs remote theme
- Add index.md as documentation homepage
- Add front matter to existing docs for navigation
- Add GitHub Actions workflow for Pages deployment